### PR TITLE
Update name of dixie.edu

### DIFF
--- a/lib/domains/edu/dixie.txt
+++ b/lib/domains/edu/dixie.txt
@@ -1,1 +1,1 @@
-Dixie College
+Dixie State University


### PR DESCRIPTION
Dixie College was renamed and is now officially Dixie State University. The domain name is unchanged.
